### PR TITLE
Fix decomposer crash

### DIFF
--- a/boustrophedon_server/src/boustrophedon_server/cellular_decomposition/polygon_decomposer.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/cellular_decomposition/polygon_decomposer.cpp
@@ -328,10 +328,12 @@ void PolygonDecomposer::sliceNewCell(const Point& upper, const Point& lower)
   // we also need the lower point, so append it one more time
   new_cell.points.push_back(*it);
 
+  Polygon new_cell_polygon = new_cell.toPolygon();
+
   // remove the points of new_cell (except upper and lower!) from the working cell
-  auto new_cell_iterator = new_cell.toPolygon().vertices_begin();
+  auto new_cell_iterator = new_cell_polygon.vertices_begin();
   new_cell_iterator++;  // skip upper
-  for (; new_cell_iterator != new_cell.toPolygon().vertices_end() - 1; new_cell_iterator++)
+  for (; new_cell_iterator != new_cell_polygon.vertices_end() - 1; new_cell_iterator++)
   {
     // for each point in the new cell, we need to remove it from the working cell
     working_cell.points.erase(findPointInVector(*new_cell_iterator, working_cell.points));


### PR DESCRIPTION
Fix a crash in `polygon_decomposer.cpp` that happens when handling even relatively simple polygons. The error message is:
```
[ INFO] [1644568401.566281410][/boustrophedon_server][/home/adi/Projects/coverage_planning/ws/src/boustrophedon_planner/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp:152]: Decomposing boundary polygon into sub-polygons...
free(): double free detected in tcache 2
```

# How to test
Issue can be replicated using the following polygon: (actually, this crashes for much simpler polygons, this is just what I had on hand)
```
 polygon.points[0].x = -20.39522171020508;
  polygon.points[0].y = -11.28903293609619;
  polygon.points[1].x = -19.36456108093262;
  polygon.points[1].y = -17.74880599975586;
  polygon.points[2].x = -15.45065879821777;
  polygon.points[2].y = -16.20244026184082;
  polygon.points[3].x = -14.58591461181641;
  polygon.points[3].y = -18.87181282043457;
  polygon.points[4].x = -18.58204650878906;
  polygon.points[4].y = -20.40133857727051;
  polygon.points[5].x = -10.70061016082764;
  polygon.points[5].y = -48.64326095581055;
  polygon.points[6].x = 0.7305610179901123;
  polygon.points[6].y = -42.42243576049805;
  polygon.points[7].x = -8.097957611083984;
  polygon.points[7].y = -13.25549983978271;
  polygon.points[8].x = 7.883210182189941;
  polygon.points[8].y = -9.471321105957031;
  polygon.points[9].x = 0.9409286975860596;
  polygon.points[9].y = 16.69508171081543;
  polygon.points[10].x = 0.4150875806808472;
  polygon.points[10].y = 16.58206748962402;
  polygon.points[11].x = 0.1012660264968872;
  polygon.points[11].y = 17.86614227294922;
  polygon.points[12].x = 0.6538788080215454;
  polygon.points[12].y = 17.96273231506348;
  polygon.points[13].x = -0.8210380077362061;
  polygon.points[13].y = 23.57880783081055;
  polygon.points[14].x = -13.47920417785645;
  polygon.points[14].y = 20.91903495788574;
  polygon.points[15].x = -12.0168399810791;
  polygon.points[15].y = 14.62396907806396;
  polygon.points[16].x = -4.097619533538818;
  polygon.points[16].y = 16.85947418212891;
  polygon.points[17].x = 0.97882080078125;
  polygon.points[17].y = -4.549089431762695;
  polygon.points[18].x = -7.554545402526855;
  polygon.points[18].y = -7.113505840301514;
```

Should fix issue #18 (same error message) and maybe some of the other crashes related issues.