### PR TITLE
Changed publishers to be latched and added new service to retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,68 @@ and returns a `StripingPlan` message which contains a list of waypoints to strip
 This repository is subject to GNU General Public License version 3 or later due to its dependencies.
 
 The geometric operations rely on CGAL which is restricted by GNU General Public License version 3 or later.
+
+## Errors: 
+Make sure that the command: `rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO` is run to install the rosparam_shortcuts dependency
+```sh
+Errors     << boustrophedon_server:cmake /home/globotix/catkin_flexa/logs/boustrophedon_server/build.cmake.001.log                                                                                        
+CMake Warning (dev) at CMakeLists.txt:2 (project):
+  Policy CMP0048 is not set: project() command manages VERSION variables.
+  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
+  command to set the policy and suppress this warning.
+
+  The following variable(s) would be set to empty:
+
+    CMAKE_PROJECT_VERSION
+    CMAKE_PROJECT_VERSION_MAJOR
+    CMAKE_PROJECT_VERSION_MINOR
+    CMAKE_PROJECT_VERSION_PATCH
+This warning is for project developers.  Use -Wno-dev to suppress it.
+
+CMake Error at /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
+  Could not find a package configuration file provided by
+  "rosparam_shortcuts" with any of the following names:
+
+    rosparam_shortcutsConfig.cmake
+    rosparam_shortcuts-config.cmake
+
+  Add the installation prefix of "rosparam_shortcuts" to CMAKE_PREFIX_PATH or
+  set "rosparam_shortcuts_DIR" to a directory containing one of the above
+  files.  If "rosparam_shortcuts" provides a separate development package or
+  SDK, be sure it has been installed.
+Call Stack (most recent call first):
+  CMakeLists.txt:6 (find_package)
+```
+
+
+Take note that the following error does not matter (for now):
+
+```sh
+executing command [sudo -H apt-get install -y ros-noetic-rosparam-shortcuts]
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+The following NEW packages will be installed:
+  ros-noetic-rosparam-shortcuts
+0 upgraded, 1 newly installed, 0 to remove and 635 not upgraded.
+1 not fully installed or removed.
+Need to get 42.7 kB of archives.
+After this operation, 203 kB of additional disk space will be used.
+Get:1 http://packages.ros.org/ros/ubuntu focal/main amd64 ros-noetic-rosparam-shortcuts amd64 0.4.0-1focal.20220106.234044 [42.7 kB]
+Fetched 42.7 kB in 1s (36.9 kB/s)                        
+Selecting previously unselected package ros-noetic-rosparam-shortcuts.
+(Reading database ... 508400 files and directories currently installed.)
+Preparing to unpack .../ros-noetic-rosparam-shortcuts_0.4.0-1focal.20220106.234044_amd64.deb ...
+Unpacking ros-noetic-rosparam-shortcuts (0.4.0-1focal.20220106.234044) ...
+Setting up ros-noetic-rosparam-shortcuts (0.4.0-1focal.20220106.234044) ...
+Setting up jami-all (20220201.1741.98ba27e~dfsg1-1) ...
+dpkg: error processing package jami-all (--configure):
+ installed jami-all package post-installation script subprocess returned error exit status 1
+Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
+Errors were encountered while processing:
+ jami-all
+E: Sub-process /usr/bin/dpkg returned an error code (1)
+ERROR: the following rosdeps failed to install
+  apt: command [sudo -H apt-get install -y ros-noetic-rosparam-shortcuts] failed
+
+```

--- a/boustrophedon_msgs/CMakeLists.txt
+++ b/boustrophedon_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ add_message_files(
 add_service_files(
   FILES
   ConvertPlanToPath.srv
+  ProducePath.srv
 )
 
 add_action_files(

--- a/boustrophedon_msgs/action/PlanMowingPath.action
+++ b/boustrophedon_msgs/action/PlanMowingPath.action
@@ -1,5 +1,8 @@
+# Goal Definition
 geometry_msgs/PolygonStamped property
 geometry_msgs/PoseStamped robot_position
 ---
+# Result Definition
 boustrophedon_msgs/StripingPlan plan
 ---
+# Feedback Definition

--- a/boustrophedon_msgs/srv/ProducePath.srv
+++ b/boustrophedon_msgs/srv/ProducePath.srv
@@ -1,0 +1,3 @@
+
+---
+nav_msgs/Path path

--- a/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
+++ b/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
@@ -35,6 +35,7 @@ private:
   ros::Publisher preprocessed_polygon_publisher_;
   ros::Publisher path_points_publisher_;
   ros::Publisher polygon_points_publisher_;
+  ros::Publisher recent_path_publisher_;
 
   StripingPlanner striping_planner_;
   OutlinePlanner outline_planner_;

--- a/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
+++ b/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
@@ -8,6 +8,7 @@
 
 #include <boustrophedon_msgs/PlanMowingPathAction.h>
 #include <boustrophedon_msgs/ConvertPlanToPath.h>
+#include <boustrophedon_msgs/ProducePath.h>
 #include <nav_msgs/Odometry.h>
 
 #include "boustrophedon_server/cgal_utils.h"
@@ -29,6 +30,7 @@ private:
   ros::NodeHandle private_node_handle_;
   Server action_server_;
   ros::ServiceServer conversion_server_;
+  ros::ServiceServer produce_path_server_;
   ros::Publisher initial_polygon_publisher_;
   ros::Publisher preprocessed_polygon_publisher_;
   ros::Publisher path_points_publisher_;
@@ -53,9 +55,18 @@ private:
   tf::TransformListener transform_listener_{};
   bool publish_polygons_{};
   bool publish_path_points_{};
+  nav_msgs::Path stored_path_;
 
   bool convertStripingPlanToPath(boustrophedon_msgs::ConvertPlanToPath::Request& request,
                                  boustrophedon_msgs::ConvertPlanToPath::Response& response);
+
+  /**
+   * @brief Produce a complete nav_msgs/Path based on the latest stiping path 
+   * 
+   */
+  bool producePlan(boustrophedon_msgs::ProducePath::Request& request,
+                                             boustrophedon_msgs::ProducePath::Response& response);
+  
   boustrophedon_msgs::PlanMowingPathResult toResult(std::vector<NavPoint>&& path, const std::string& frame) const;
   Polygon fromBoundary(const geometry_msgs::PolygonStamped& boundary) const;
   Point fromPositionWithFrame(const geometry_msgs::PoseStamped& pose, const std::string& target_frame) const;
@@ -64,6 +75,14 @@ private:
   geometry_msgs::PolygonStamped convertCGALPolygonToMsg(const Polygon& poly) const;
   void publishPathPoints(const std::vector<NavPoint>& path) const;
   void publishPolygonPoints(const Polygon& poly) const;
+
+  /**
+   * @brief Store the latest plan generated in a nav_msgs/Path container
+   * 
+   * @param path 
+   */
+  void storeLatestPath(const std::vector<NavPoint>& path);
+
 };
 
 #endif  // SRC_BOUSTROPHEDON_PLANNER_SERVER_H

--- a/boustrophedon_server/scripts/boustrophedon_test.py
+++ b/boustrophedon_server/scripts/boustrophedon_test.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env/ python3 
+import rospy
+from geometry_msgs.msg import Pose, Point32
+from boustrophedon_msgs.msg import PlanMowingPathActionGoal, PlanMowingPathActionResult
+from std_srvs.srv import Trigger, TriggerResponse
+
+class BoustrophedonTest():
+    def __init__(self):
+        rospy.loginfo("Node has been initialised")
+        # robot_pose topic or amcl_pose topic is both fine
+        rospy.Subscriber("robot_pose", Pose, self.robotPoseSubCB, queue_size=1)
+        self.start_srv = rospy.Service('boustrophedon_start_srv', Trigger, self.startServiceCB)
+        self.boustrophedon_action_server_goal_pub = rospy.Publisher('/plan_path/goal', PlanMowingPathActionGoal, queue_size=1)
+        self.boustrophedon_action_server_goal_sub = rospy.Subscriber("/plan_path/result", PlanMowingPathActionResult, self.actionResult, queue_size=1)
+        self.robot_pose = None
+
+    def robotPoseSubCB(self, data):
+        self.robot_pose = data
+
+    def startServiceCB(self, data):
+        if (self.robot_pose is None):
+            rospy.logerr("The robot pose has not been published")
+        action_goal_message = PlanMowingPathActionGoal()
+        action_goal_message.goal.property.header.frame_id = "map"
+        action_goal_message.goal.robot_position.header.frame_id = "map"
+        action_goal_message.goal.property.header.stamp = rospy.Time.now()
+        action_goal_message.goal.robot_position.header.stamp = rospy.Time.now()
+
+        # To get these points, go to the top of rviz and click the + button and add Publish Point
+        # Then echo /clicked_point in the terminal and use the Publish Point button to obtain the coordinates of the polygon
+        points1 = Point32()
+        points1.x = -6.0
+        points1.y = -1.0
+        action_goal_message.goal.property.polygon.points.append(points1)
+
+        points2 = Point32()
+        points2.x = -1.0
+        points2.y = -1.0
+        action_goal_message.goal.property.polygon.points.append(points2)
+
+        points3 = Point32()
+        points3.x = -4.0
+        points3.y = -5.0
+        action_goal_message.goal.property.polygon.points.append(points3)
+
+        print(f"These are the points: {action_goal_message.goal.property.polygon.points}")
+
+        # Add the current position of the robot
+        action_goal_message.goal.robot_position.pose.position.x = self.robot_pose.position.x
+        action_goal_message.goal.robot_position.pose.position.y = self.robot_pose.position.y
+        action_goal_message.goal.robot_position.pose.position.z = self.robot_pose.position.z
+        action_goal_message.goal.robot_position.pose.orientation.x = self.robot_pose.orientation.x
+        action_goal_message.goal.robot_position.pose.orientation.y = self.robot_pose.orientation.y
+        action_goal_message.goal.robot_position.pose.orientation.z = self.robot_pose.orientation.z
+        action_goal_message.goal.robot_position.pose.orientation.w = self.robot_pose.orientation.w
+
+        print("Published goal to the server")
+        self.boustrophedon_action_server_goal_pub.publish(action_goal_message)
+        return(TriggerResponse())
+
+    def actionResult(self, data):
+        print(data)
+
+
+if __name__ == "__main__":
+    rospy.init_node("boustrophedon_test")
+    print('''
+    Hello welcome to the boustrophedon test script. Ensure that roslaunch boustrophedon_server boustrophedon_server.launch is running 
+    afterwhich proceed to call the following service: rosservice call /boustrophedon_start_srv "{}" 
+    ''')
+    some_instance = BoustrophedonTest()
+    rospy.spin()

--- a/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
@@ -80,6 +80,9 @@ BoustrophedonPlannerServer::BoustrophedonPlannerServer()
     preprocessed_polygon_publisher_ =
         private_node_handle_.advertise<geometry_msgs::PolygonStamped>("preprocessed_polygon", 1, true);
   }
+
+  recent_path_publisher_ = private_node_handle_.advertise<nav_msgs::Path>("recent_path_publisher", 1, true);
+
   // mainly for use with plotJuggler, which wants the points to be put one at a time on the same topic
   if (publish_path_points_)
   {
@@ -167,6 +170,9 @@ void BoustrophedonPlannerServer::executePlanPathAction(const boustrophedon_msgs:
     publishPolygonPoints(polygon);
   }
   storeLatestPath(path);
+  stored_path_.header.stamp = ros::Time::now();
+  stored_path_.header.frame_id = "map";
+  recent_path_publisher_.publish(stored_path_);
   auto result = toResult(std::move(path), boundary_frame);
   action_server_.setSucceeded(result);
 }


### PR DESCRIPTION
- Noticed that the publishers were not latched, latching them allows their results to be accessed after the service call is made without having to actively subscribe to all the topics (helpful for debugging) 
- Added a new service to retrieve the entire nav_msgs/Path instead of the version which publishes each point separately for plojuggler